### PR TITLE
Adapt to math-comp/math-comp#1166

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,12 +57,12 @@ jobs:
     - image: coqorg/coq:8.17
     resource_class: 'large'
 
-  coq-8-17-mathcomp-dev:
+  coq-8-17-mathcomp-2-2-0:
     <<: *defaults
     steps:
     - startup
     - prepare:
-        mathcomp-version: 'dev'
+        mathcomp-version: '2.2.0'
     - build
     docker:
     - image: coqorg/coq:8.17
@@ -90,6 +90,28 @@ jobs:
     - image: coqorg/coq:8.18
     resource_class: 'large'
 
+  coq-8-19-mathcomp-2-2-0:
+    <<: *defaults
+    steps:
+    - startup
+    - prepare:
+        mathcomp-version: '2.2.0'
+    - build
+    docker:
+    - image: coqorg/coq:8.19
+    resource_class: 'large'
+
+  coq-8-19-mathcomp-dev:
+    <<: *defaults
+    steps:
+    - startup
+    - prepare:
+        mathcomp-version: 'dev'
+    - build
+    docker:
+    - image: coqorg/coq:8.19
+    resource_class: 'large'
+
   coq-dev:
     <<: *defaults
     steps:
@@ -105,7 +127,9 @@ workflows:
   build:
     jobs:
     - coq-8-17-mathcomp-2-0-0
-    - coq-8-17-mathcomp-dev
+    - coq-8-17-mathcomp-2-2-0
     - coq-8-18-mathcomp-2-0-0
     - coq-8-18-mathcomp-dev
+    - coq-8-19-mathcomp-2-2-0
+    - coq-8-19-mathcomp-dev
     - coq-dev

--- a/coq-deriving.opam
+++ b/coq-deriving.opam
@@ -11,7 +11,7 @@ license: "MIT"
 build: [ make "-j" "%{jobs}%" "test" {with-test} ]
 install: [ make "install" ]
 depends: [
-  "coq" { (>= "8.17" & < "8.19~") | (= "dev") }
+  "coq" { (>= "8.17" & < "8.20~") | (= "dev") }
   "coq-mathcomp-ssreflect" {>= "2.0" | (= "dev")}
 ]
 

--- a/theories/base.v
+++ b/theories/base.v
@@ -1,6 +1,6 @@
 From HB Require Import structures.
 From mathcomp Require Import
-  ssreflect ssrfun ssrbool ssrnat eqtype seq choice fintype.
+  ssreflect ssrfun ssrbool ssrnat eqtype seq choice fintype order.
 
 Set Implicit Arguments.
 Unset Strict Implicit.
@@ -1308,3 +1308,13 @@ Definition hnth1 m :=
 Coercion hnth1 : hlist1 >-> Funclass.
 #[global]
 Hint Unfold hnth1 : deriving.
+
+(* Compatibility layer for Order.disp_t introduced in MathComp 2.3            *)
+(* TODO: remove when we drop the support for MathComp 2.2                     *)
+Module Order.
+Import Order.
+Definition disp_t : Set.
+Proof. exact: disp_t || exact: unit. Defined.
+Definition default_display : disp_t.
+Proof. exact: tt || exact: Disp tt tt. Defined.
+End Order.

--- a/theories/instances.v
+++ b/theories/instances.v
@@ -38,7 +38,7 @@ Definition option_indDef T :=
 Canonical option_indType T :=
   IndType (option T) (option_indDef T).
 Section OptionOrderType.
-Variable Tord : orderType tt.
+Variable Tord : orderType Order.default_display.
 Definition option_isOrder :=
   Eval hnf in [derive isOrder for option Tord].
 HB.instance Definition _ := option_isOrder.

--- a/theories/instances/order.v
+++ b/theories/instances/order.v
@@ -17,7 +17,7 @@ Section DerOrderType.
 Import Order.Total Order.Theory.
 
 Record packedOrderType := Pack {
-  disp : unit;
+  disp : Order.disp_t;
   sort : orderType disp;
 }.
 
@@ -148,7 +148,7 @@ Qed.
 
 Definition ind_isOrder i :=
   Eval unfold Order.isOrder.phant_Build in
-  Order.isOrder.Build tt (T i)
+  Order.isOrder.Build Order.default_display (T i)
     (fun _ _ => erefl) (fun _ _ => erefl) (fun _ _ => erefl)
     (@anti i) (@trans i) (@total i).
 
@@ -172,7 +172,7 @@ Canonical packOrderType disp (T : orderType disp) :=
 
 Notation "[ 'derive' 'nored' 'isOrder' 'for' T ]" :=
   (@DerOrderType.pack T%type _ id _ _ _ _ _ _ id _ id _ id _ id _ id _ id :
-    Order.isOrder tt T%type
+    Order.isOrder Order.default_display T%type
   )
   (at level 0) : form_scope.
 


### PR DESCRIPTION
We plan to change the type of the display parameter of the order type structures in order.v (see math-comp/math-comp#1166). This PR provides a compatibility layer.