### PR TITLE
Split test and bench targets

### DIFF
--- a/.github/workflows/cachix-install-nix-action.yml
+++ b/.github/workflows/cachix-install-nix-action.yml
@@ -3,6 +3,7 @@ name: Nix Flake actions
 on:
   pull_request:
   push:
+    branches: [ master ]
 
 jobs:
   nix-matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `make test` no longer runs benchmarks.  Use `make bench` for
+  benchmarks alone, or `make check` for both tests and benchmarks
+  (this is what CI runs).
+
 ### Deprecated
 
 ### Removed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,11 @@
 
 ## Running the tests
 
-Run `make test` from the repo root (inside `nix develop` if you use the
-flake) to build the library and run the entire test suite.
+There are three useful targets:
+
+- `make test` — run the end-to-end functionality tests only (fast).
+- `make bench` — run the performance benchmarks only.
+- `make check` — run both (`test` + `bench`).  This is what CI runs.
 
 There are two kinds of tests:
 

--- a/CoqMakefile.local
+++ b/CoqMakefile.local
@@ -10,6 +10,9 @@ theories/tactics.v: make_tactics.ml $(UNFOLDFILES)
 test: $(TESTVOFILES)
 .PHONY: test
 
+check: test bench
+.PHONY: check
+
 .CoqMakefile.test.d: $(TESTVFILES)
 	$(SHOW)'COQDEP TESTVFILES'
 	$(HIDE)$(COQDEP) -vos -dyndep var $(COQMF_COQLIBS_NOML) $^ $(redir_if_ok)

--- a/bench/bench.mk
+++ b/bench/bench.mk
@@ -17,8 +17,6 @@ BENCH_OCAML     = ocaml -I $(shell ocamlfind query csv) csv.cma
 bench: $(BENCH_PNGS)
 .PHONY: bench
 
-test: bench
-
 $(BENCH_BUILD)/bench-deps.mk: $(BENCH_CSVS) bench/gen_mk.awk
 	$(SHOW)'BENCH-DEPS $@'
 	$(HIDE)mkdir -p $(@D)

--- a/flake.nix
+++ b/flake.nix
@@ -93,7 +93,6 @@
               coqPackages.overrideScope (final': prev': {
                 deriving = prev'.lib.overrideCoqDerivation {
                   version = ./.;
-                  checkTarget = "test";
                   checkFlags = [ "VERBOSE=" ];
                   # The nixpkgs coq setup hook sets COQPATH for dependency
                   # lookup, but rocq 9.0+ warns that COQPATH is deprecated in


### PR DESCRIPTION
`make test` now only runs the end-to-end functionality tests in tests/*.v.  `make bench` runs the performance benchmarks alone. A new `make check` target runs both, and the flake's checkTarget is updated accordingly so CI still exercises everything.