### PR TITLE
Add rocq-mcp AI development shell.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,10 @@ make install      # Install via opam
 
 Alternative: `nix build` or `nix develop` (provides dev shell with coq-lsp).
 
+Use `nix develop .#ai` to enter the AI-assisted development shell,
+which includes `rocq-mcp` (a Rocq MCP server) in addition to the
+default shell's dependencies.
+
 ## Build System
 
 - `Makefile` generates `CoqMakefile` from `_CoqProject` using `coq_makefile`, then delegates to it.

--- a/flake.lock
+++ b/flake.lock
@@ -18,6 +18,24 @@
         "type": "github"
       }
     },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "nix-github-actions": {
       "inputs": {
         "nixpkgs": [
@@ -69,11 +87,82 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib_2": {
+      "locked": {
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "pytanque": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776538811,
+        "narHash": "sha256-1Hae21BuMdE6MjRdiBO7fcsuS4HzahOdLLhynAUox3I=",
+        "owner": "LLM4Rocq",
+        "repo": "pytanque",
+        "rev": "4092b1238b56468fdc1b3d100e078791c9690fd4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "LLM4Rocq",
+        "repo": "pytanque",
+        "type": "github"
+      }
+    },
+    "rocq-mcp": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "pytanque": "pytanque",
+        "rocq-mcp": "rocq-mcp_2"
+      },
+      "locked": {
+        "lastModified": 1777473647,
+        "narHash": "sha256-FCkPQt9NvB5MAiYvWto+Egy3V6q4trEzYgaBB56uKJU=",
+        "owner": "arthuraa",
+        "repo": "rocq-mcp-flake",
+        "rev": "6b6f2870366e51bbf896566ff54672abd092f9e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "arthuraa",
+        "repo": "rocq-mcp-flake",
+        "type": "github"
+      }
+    },
+    "rocq-mcp_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1776328817,
+        "narHash": "sha256-R+alv6VrLtoN/iCwzIwD4gf7ZU2RY3xH99HvB6j9HPg=",
+        "owner": "LLM4Rocq",
+        "repo": "rocq-mcp",
+        "rev": "56929d2ba6ec92a078177739f4118b9abbf6d641",
+        "type": "github"
+      },
+      "original": {
+        "owner": "LLM4Rocq",
+        "repo": "rocq-mcp",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "nix-github-actions": "nix-github-actions",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rocq-mcp": "rocq-mcp"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -11,9 +11,11 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     nix-github-actions.url = "github:nix-community/nix-github-actions";
     nix-github-actions.inputs.nixpkgs.follows = "nixpkgs";
+    rocq-mcp.url = "github:arthuraa/rocq-mcp-flake";
+    rocq-mcp.inputs.nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = inputs@{ self, flake-parts, nixpkgs, nix-github-actions, ... }:
+  outputs = inputs@{ self, flake-parts, nixpkgs, nix-github-actions, rocq-mcp, ... }:
     let
       # Coq/Rocq package sets we test against.  The first entry is exposed as
       # packages.default / checks.default.  Used by the overlay (to decide what
@@ -52,6 +54,26 @@
             self'.checks.default
           ];
         };
+
+        devShells.ai =
+          let
+            aiPkgs = import self.inputs.nixpkgs {
+              inherit system;
+              overlays = [
+                self.overlays.default
+                rocq-mcp.overlays.default
+              ];
+            };
+          in
+          pkgs.mkShell {
+            propagatedBuildInputs = [
+              pkgs.coqPackages.coq-lsp
+              aiPkgs.rocq-mcp
+            ];
+            inputsFrom = [
+              self'.checks.default
+            ];
+          };
 
         packages =
           let packagesByVersion =


### PR DESCRIPTION
New flake input rocq-mcp (github:arthuraa/rocq-mcp-flake) and a devShells.ai that provides rocq-mcp alongside the usual build dependencies.  Use `nix develop .#ai` to enter it.